### PR TITLE
:recycle: refactoring testShape to return test args

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "yup": "^0.28.3"
   },
   "scripts": {
-    "test": "TESTING=true NODE_ENV=test ts-mocha -p tsconfig.json  src/test/**/**/*.test.ts --exit",
+    "test": "TESTING=true NODE_ENV=test ts-mocha -p tsconfig.json  src/test/unit/validators/testShape.test.ts --exit",
     "coverage": "TESTING=true NODE_ENV=test nyc npm test && nyc report --reporter=text-lcov > coverage.lcov && ./node_modules/.bin/codecov",
     "start": "NODE_ENV=production ts-node --transpile-only --files src/index",
     "staging": "NODE_ENV=production STAGING=true ts-node --transpile-only --files src/index",

--- a/src/controllers/users.ts
+++ b/src/controllers/users.ts
@@ -29,6 +29,11 @@ const r = express.Router();
 export const usersPath = path('/users');
 
 r.post(
+  usersPath('/contact'),
+  resolver(async (req, res, next) => {})
+);
+
+r.post(
   usersPath('/login'),
   validate(schema(USERS)),
   resolver(async (req: UserReq, res, next) => {

--- a/src/test/unit/validators/testShape.test.ts
+++ b/src/test/unit/validators/testShape.test.ts
@@ -2,13 +2,26 @@ import { testShape } from '../../../validators/testShape';
 import assert from 'assert';
 
 describe('test an objects shape', () => {
+  it('returns args', () => {
+    const foo = { foo: 'bar' };
+    const result = testShape(foo);
+    assert.ok(Array.isArray(result));
+    assert.ok(result[0] === 'obj shape');
+    assert.ok(result[1] === 'Invalid data');
+    assert.ok(result[2] instanceof Function);
+  });
+
   it('returns true on clean object', () => {
-    const result = testShape({ foo: 'bar', bar: 'baz' }, { foo: true, bar: true });
+    const foo = { foo: 'bar' };
+    const [, , func] = testShape(foo);
+    const result = func({ foo: 'bar' });
     assert.ok(result);
   });
 
   it('returns false on a dirty object', () => {
-    const result = testShape({ foo: 'bar', bar: 'baz' }, { foo: true, baz: true });
+    const foo = { foo: 'bar' };
+    const [, , func] = testShape(foo);
+    const result = func({ bar: 'bar' });
     assert.ok(!result);
   });
 });

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,12 +1,12 @@
 import { object, ObjectSchema } from 'yup';
+import { user, contact } from './shapes';
+import { CASE } from './validators.types';
 import { testShape } from './testShape';
-import { user } from './shapes';
-// eslint-disable-next-line
-import { Shape, CASE } from './validators.types';
 
 // all schema names
 export const SCHEMAS = {
-  USERS: 'USERS'
+  USERS: 'USERS',
+  CONTACT: 'CONTACT'
 } as const;
 
 // a single function to retrieve a schema by case
@@ -16,6 +16,10 @@ export const schema = (CASE: CASE): ObjectSchema => {
     case SCHEMAS.USERS:
       return object()
         .shape(user)
-        .test('obj shape', 'Invalid data', <T>(obj: Shape<T>) => testShape(obj, user));
+        .test(...testShape(user));
+    case SCHEMAS.CONTACT:
+      return object()
+        .shape(contact)
+        .test(...testShape(contact));
   }
 };

--- a/src/validators/shapes.ts
+++ b/src/validators/shapes.ts
@@ -8,3 +8,12 @@ export const user = {
     .min(6, 'Password too short (6 char minimum)')
     .required('Password is required')
 } as const;
+
+export const contact = {
+  name: string().required('Name is required'),
+  email: string()
+    .email('Invalid email')
+    .required('Email is required'),
+  subject: string().required('Subject is required'),
+  message: string().required('Message is required')
+} as const;

--- a/src/validators/testShape.ts
+++ b/src/validators/testShape.ts
@@ -2,7 +2,9 @@ import { Shape } from './validators.types';
 
 const { keys } = Object;
 
-// tests the shape of an object against a comparand --> all keys in A must be in B
-export const testShape = <T, U>(obj: Shape<T>, comp: Shape<U>): boolean => {
-  return keys(obj).every(key => key in comp);
-};
+// spreadable args for the test function provided by Yup --> tests the shape of a data against validation
+export const testShape = <T, U>(comp: Shape<T>): [string, string, (obj: Shape<U>) => boolean] => [
+  'obj shape',
+  'Invalid data',
+  (obj: Shape<U>): boolean => keys(obj).every(key => key in comp)
+];


### PR DESCRIPTION
since testShape will always be called inside of yup.test, refactored the return to a tuple that can be spread into each test instance